### PR TITLE
Add noto sans cjk font to QT image

### DIFF
--- a/images/linux-gcc-5-qt-5.9
+++ b/images/linux-gcc-5-qt-5.9
@@ -1,9 +1,10 @@
 FROM mbgl/linux-gcc-5
 
-# Install Qt installer dependencies
+# Install Qt installer dependencies and fonts-noto-cjk font
+# that is used for local glyph rasterizer unit tests.
 RUN set -eu \
  && apt-get update \
- && apt-get -y install dbus \
+ && apt-get -y install dbus fonts-noto-cjk \
  && rm -rf /var/lib/apt/lists/*
 
 # Use most recent version from http://download.qt.io/archive/qt/ and update the checksum.


### PR DESCRIPTION
Add noto sans cjk font to QT image
[docker:linux-gcc-5-qt-5.9]