### PR TITLE
[docker:android-ndk-r21e] Add build-tools 30.0.2

### DIFF
--- a/images/android-ndk-r21e
+++ b/images/android-ndk-r21e
@@ -30,6 +30,7 @@ RUN set -eu \
         "build-tools;28.0.3" \
         "platforms;android-29" \
         "build-tools;29.0.2" \
+        "build-tools;30.0.2" \
         "build-tools;30.0.3" \
         "platforms;android-30" \
         "extras;android;m2repository" \


### PR DESCRIPTION
This PR adds  build-tools 30.0.2 to the android-ndk-r21e image, https://developer.android.com/studio/releases/gradle-plugin#compatibility_2 the default version for Android gradle plugin 4.2.x is set to 30.0.2