### PR TITLE
[docker:android-ndk-r22] Add build tools `29.0.2`

### DIFF
--- a/images/android-ndk-r22
+++ b/images/android-ndk-r22
@@ -36,6 +36,7 @@ RUN set -eu \
         "--sdk_root=${ANDROID_HOME}" \
         "platform-tools" \
         "build-tools;28.0.3" \
+        "build-tools;29.0.2" \
         "build-tools;29.0.3" \
         "build-tools;30.0.2" \
         "build-tools;30.0.3" \


### PR DESCRIPTION
Add build tools `29.0.2` to `android-ndk-r22`.

Seeing an issue in https://github.com/mapbox/mapbox-navigation-android/pull/5102 https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/14738/workflows/fa663f16-7efc-4904-b7ba-84bb6ec6e95c/jobs/62654

```
Crashlytics could not find NDK build tasks on which to depend. You many need to manually enforce task dependencies for generateCrashlyticsSymbolFileRelease
File /root/.android/repositories.cfg could not be loaded.
Checking the license for package Android SDK Build-Tools 29.0.2 in /android/sdk/licenses
Warning: License for package Android SDK Build-Tools 29.0.2 not accepted.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':libnavigation-router:compileDebugJavaWithJavac'.
> Failed to install the following Android SDK packages as some licences have not been accepted.
     build-tools;29.0.2 Android SDK Build-Tools 29.0.2
  To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
  Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
  
  Using Android SDK: /android/sdk
```

cc @Zayankovsky   