### PR TITLE
[docker:android-base] Support JDK-11 and build-tool 31.

### DIFF
--- a/images/android-base
+++ b/images/android-base
@@ -15,7 +15,7 @@ RUN set -eu \
 
 RUN set -eu \
  && apt-get update \
- && apt-get -y install unzip ccache openjdk-8-jdk-headless apt-transport-https software-properties-common \
+ && apt-get -y install unzip ccache openjdk-11-jdk-headless apt-transport-https software-properties-common \
  && rm -rf /var/lib/apt/lists/*
 
 # Install CLI tools for CI scripting

--- a/images/android-ndk-r21e
+++ b/images/android-ndk-r21e
@@ -6,8 +6,8 @@ WORKDIR /android/sdk
 # Use most recent version from https://developer.android.com/studio/index.html#command-tools
 # and update the checksum.
 RUN set -eu \
- && curl -L --retry 3 https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip -o tools.zip \
- && (echo "f10f9d5bca53cc27e2d210be2cbc7c0f1ee906ad9b868748d74d62e10f2c8275  tools.zip" | sha256sum -c) \
+ && curl -L --retry 3 https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip -o tools.zip \
+ && (echo "124f2d5115eee365df6cf3228ffbca6fc3911d16f8025bebd5b1c6e2fcfa7faf  tools.zip" | sha256sum -c) \
  && unzip -q tools.zip && rm tools.zip
 
 # Install Android NDK
@@ -23,7 +23,7 @@ RUN set -eu \
 RUN set -eu \
  && mkdir -p "${ANDROID_HOME}/licenses" \
  && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "${ANDROID_HOME}/licenses/android-sdk-license" \
- && tools/bin/sdkmanager \
+ && cmdline-tools/bin/sdkmanager \
         "--sdk_root=${ANDROID_HOME}" \
         "platform-tools" \
         "platforms;android-28" \
@@ -32,6 +32,7 @@ RUN set -eu \
         "build-tools;29.0.2" \
         "build-tools;30.0.2" \
         "build-tools;30.0.3" \
+        "build-tools;31.0.0" \
         "platforms;android-30" \
         "platforms;android-31" \
         "extras;android;m2repository" \


### PR DESCRIPTION
- Update jdk 11 to support gradle bump.
- Added build tool 31.