### PR TITLE
Add `android-ndk-r22-jdk17` image

### DIFF
--- a/images/android-ndk-r22-jdk17
+++ b/images/android-ndk-r22-jdk17
@@ -1,0 +1,56 @@
+FROM mbgl/android-base
+
+WORKDIR /android/sdk
+
+# Install JDK 17
+RUN set -eu \
+ && add-apt-repository ppa:openjdk-r/ppa
+ENV JAVA_HOME=/usr/lib/jvm/java-1.17.0-openjdk-amd64
+RUN set -eu \
+ && apt-get update \
+ && apt-get -y install openjdk-17-jdk-headless \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Android SDK
+# Use most recent version from https://developer.android.com/studio/index.html#command-tools
+# and update the checksum.
+RUN set -eu \
+ && curl -L --retry 3 https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip -o tools.zip \
+ && (echo "f10f9d5bca53cc27e2d210be2cbc7c0f1ee906ad9b868748d74d62e10f2c8275  tools.zip" | sha256sum -c) \
+ && unzip -q tools.zip && rm tools.zip
+
+# Install Android NDK
+# Use desired version from https://developer.android.com/ndk/downloads/index.html
+# and update the checksum.
+RUN set -eu \
+ && curl -L --retry 3 https://dl.google.com/android/repository/android-ndk-r22-linux-x86_64.zip -o ndk.zip \
+ && (echo "82274313aba10da6177fd41868f56a0f9651dd81  ndk.zip" | sha1sum -c) \
+ && unzip -q ndk.zip && rm ndk.zip && mv android-ndk-r* ndk-bundle
+
+# Install dependencies and build tools
+
+RUN set -eu \
+ && mkdir -p "${ANDROID_HOME}/licenses" \
+ && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "${ANDROID_HOME}/licenses/android-sdk-license" \
+ && tools/bin/sdkmanager \
+        "--sdk_root=${ANDROID_HOME}" \
+        "platform-tools" \
+        "build-tools;28.0.3" \
+        "build-tools;29.0.2" \
+        "build-tools;29.0.3" \
+        "build-tools;30.0.2" \
+        "build-tools;30.0.3" \
+        "platforms;android-33" \        
+        "platforms;android-32" \            
+        "platforms;android-31" \
+        "platforms;android-30" \
+        "platforms;android-29" \
+        "platforms;android-28" \
+        "extras;android;m2repository" \
+        "patcher;v4" \
+        "extras;google;m2repository" \
+        "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
+        "cmake;3.10.2.4988404" \
+ && rm -rf "${ANDROID_HOME}/licenses"
+
+WORKDIR /src


### PR DESCRIPTION
- Adds `android-ndk-r22-jdk17` image

Refs. https://github.com/mapbox/navigation/pull/609

https://app.circleci.com/pipelines/github/mapbox/navigation/1807/workflows/ddd7ebfa-21b0-4b02-b69e-0129c14b3b4d/jobs/12581

```
* What went wrong:
An exception occurred applying plugin request [id: 'com.android.application']
> Failed to apply plugin 'com.android.internal.application'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 15.
      Your current JDK is located in /usr/lib/jvm/java-15-openjdk-amd64
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```

cc @LukasPaczos        