### PR TITLE
[docker:android-ndk-r22-jdk17] Adds `build-tools;33.0.2` to `android-ndk-r22-jdk17` image

### DIFF
--- a/images/android-ndk-r22-jdk17
+++ b/images/android-ndk-r22-jdk17
@@ -40,7 +40,8 @@ RUN set -eu \
         "build-tools;29.0.3" \
         "build-tools;30.0.2" \
         "build-tools;30.0.3" \
-        "platforms;android-33" \        
+        "build-tools;33.0.2" \
+        "platforms;android-33" \
         "platforms;android-32" \            
         "platforms;android-31" \
         "platforms;android-30" \


### PR DESCRIPTION
[docker:android-ndk-r22-jdk17]

- Adds `build-tools;33.0.2` to `android-ndk-r22-jdk17` image