### PR TITLE
[docker:android-base] Add Kotlin command-line compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ When you want to add a new image, e.g. a new compiler version or a new Android N
 
 ### Updating a new image
 
-When you want to update an existing image, e.g. update dependencies, new feature, edit an existing file in the `images` directory, and change it to suit your needs. If the image you're modifying serves as a base for other images you also need to build the derived images, for example [PR#88](https://github.com/mapbox/mbgl-ci-images/pull/88).
+When you want to update an existing image, e.g. update dependencies, new feature, etc. edit an existing file in the `images` directory, and change it to suit your needs. If the image you're modifying serves as a base for other images (i.e. used in `FROM` command like in [android-sdk](https://github.com/mapbox/mbgl-ci-images/blob/master/images/android-sdk#L1)) you also need to build the derived images, for example [PR#88](https://github.com/mapbox/mbgl-ci-images/pull/88).
 
 ### Workflow
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ This repository contains Docker files for running [Mapbox GL](https://github.com
 
 ### Adding a new image
 
-When you want to add a new image, e.g. a new compiler version or a new Android NDK version, duplicate an existing file in the `images` directory, annd change it to suit your needs. There's usually no need to keep previous versions of e.g. the Android NDK around. Legacy branches of mapbox-gl-native will use legacy Docker images that contain the legacy NDKs.
+When you want to add a new image, e.g. a new compiler version or a new Android NDK version, duplicate an existing file in the `images` directory, and change it to suit your needs. There's usually no need to keep previous versions of e.g. the Android NDK around. Legacy branches of mapbox-gl-native will use legacy Docker images that contain the legacy NDKs.
+
+### Updating a new image
+
+When you want to update an existing image, e.g. update dependencies, new feature, edit an existing file in the `images` directory, and change it to suit your needs. If the image you're modifying serves as a base for other images you also need to build the derived images, for example [PR#88](https://github.com/mapbox/mbgl-ci-images/pull/88).
 
 ### Workflow
 

--- a/images/android-base
+++ b/images/android-base
@@ -20,7 +20,7 @@ RUN set -eu \
 
 # Install CLI tools for CI scripting
 RUN set -eu \
- && apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059 \
  && apt-add-repository https://cli.github.com/packages \
  && apt-get update \
  && apt-get -y install jq gh \

--- a/images/android-base
+++ b/images/android-base
@@ -54,3 +54,10 @@ ENV ANDROID_NDK_HOME=/android/sdk/ndk-bundle \
 #install Microsoft app center
 RUN set -eu \
  && npm install -g appcenter-cli
+
+# Install Kotlin Command-line compiler (https://kotlinlang.org/docs/command-line.html)
+RUN set -eu \
+ && wget -O /root/kotlin-compiler-1.9.21.zip https://github.com/JetBrains/kotlin/releases/download/v1.9.21/kotlin-compiler-1.9.21.zip \
+ && unzip /root/kotlin-compiler-1.9.21.zip -d / \
+ && rm /root/kotlin-compiler-1.9.21.zip
+ENV PATH="/kotlinc/bin:$PATH"

--- a/images/android-ndk-r23-lts
+++ b/images/android-ndk-r23-lts
@@ -32,7 +32,6 @@ RUN set -eu \
         "platforms;android-33" \
         "platforms;android-34" \
         "extras;android;m2repository" \
-        "patcher;v4" \
         "extras;google;m2repository" \
         "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
         "cmake;3.22.1" \

--- a/images/android-sdk
+++ b/images/android-sdk
@@ -23,7 +23,6 @@ RUN set -eu \
         "platforms;android-33" \
         "platforms;android-34" \
         "extras;android;m2repository" \
-        "patcher;v4" \
         "extras;google;m2repository" \
         "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
         "cmake;3.22.1" \


### PR DESCRIPTION
Added Kotlin command-line compiler 1.9.21 to `/kotlinc/` and also to the `PATH` env variable.

I also had to update the Github new key. See note in https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt:
> **Note**
> We were recently forced to change our GPG signing key. If you've previously downloaded the `githubcli-archive-keyring.gpg` file, you should re-download it again per above instructions. If you are using a keyserver to download the key, the ID of the new key is `23F3D4EA75716059`.