### PR TITLE
[docker:android-ndk-r22-jdk17] Adds "Accept all Android SDK liceses" step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,13 @@ version: 2
 
 jobs:
   build:
-    working_directory: /app
+    working_directory: ~/app
     docker:
-      - image: docker:18.05.0-ce-git
+      - image: cimg/base:2024.10
     steps:
       - checkout
-      - run:
-          name: Install dependencies
-          command: apk add --no-progress bash
       - setup_remote_docker:
-          version: 18.05.0-ce
+          version: docker24
       - run:
           name: Log in to Docker Hub
           command: docker login -u mbgl -p ${DOCKER_PASS}

--- a/images/android-ndk-r22-jdk17
+++ b/images/android-ndk-r22-jdk17
@@ -32,7 +32,7 @@ RUN set -eu \
 RUN set -eu \
  && mkdir -p "${ANDROID_HOME}/licenses" \
  && echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "${ANDROID_HOME}/licenses/android-sdk-license" \
- && tools/bin/sdkmanager \
+ && tools/bin/sdkmanager --include_obsolete \
         "--sdk_root=${ANDROID_HOME}" \
         "platform-tools" \
         "build-tools;28.0.3" \
@@ -50,8 +50,10 @@ RUN set -eu \
         "platforms;android-28" \
         "extras;android;m2repository" \
         "extras;google;m2repository" \
-        "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2" \
         "cmake;3.10.2.4988404" \
  && rm -rf "${ANDROID_HOME}/licenses"
+
+# Accept all Android SDK licenses
+RUN yes | tools/bin/sdkmanager "--sdk_root=${ANDROID_HOME}" --licenses
 
 WORKDIR /src


### PR DESCRIPTION
[docker:android-ndk-r22-jdk17]

- Adds `RUN yes | tools/bin/sdkmanager "--sdk_root=${ANDROID_HOME}" --licenses` to `android-ndk-r22-jdk17` docker image
- Removed obsolete `extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2` package